### PR TITLE
Use the latest version of politburo and rename templates_base to template accordingly

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "css-loader": "^0.14.5",
     "html-webpack-plugin": "^1.6.1",
     "node-libs-browser": "^0.5.2",
-    "politburo": "0.0.1",
+    "politburo": "1.1.1",
     "style-loader": "^0.12.3",
     "webpack": "^1.11.0"
   },

--- a/src/ChatUnion/ChatBox/ChatBoxCulture.js
+++ b/src/ChatUnion/ChatBox/ChatBoxCulture.js
@@ -60,7 +60,7 @@ export default class ChatBoxCulture extends Culture {
         }
     }
 
-    templates_base() {
+    template() {
         return `<chat-box id="${this.id}">
                 <header>
                     <img src="${this.rep.user.picture.thumbnail}"/>

--- a/src/ChatUnion/ChatPane/ChatPaneCulture.js
+++ b/src/ChatUnion/ChatPane/ChatPaneCulture.js
@@ -25,7 +25,7 @@ export default class ChatPaneCulture extends Culture {
         thread.scrollTop = thread.scrollHeight;
     }
 
-    templates_base() {
+    template() {
         return `<chat-pane id="${this.id}">
             ${this.templates_inner()}
             </chat-pane>`;

--- a/src/ChatUnion/Menu/MenuCulture.js
+++ b/src/ChatUnion/Menu/MenuCulture.js
@@ -22,7 +22,7 @@ export default class MenuCulture extends Culture {
         this.popover.toggle();
     }
 
-    templates_base() {
+    template() {
         return `<menu id="${this.id}">
             <h1>Chat</h1>
             <button>${this.templates_button()}</button>

--- a/src/ChatUnion/MotherPane/MotherPaneCulture.js
+++ b/src/ChatUnion/MotherPane/MotherPaneCulture.js
@@ -28,7 +28,7 @@ export default class MotherPaneCulture extends Culture {
         this.rep.setActive(threadPreview.thread);
     }
 
-    templates_base() {
+    template() {
         return `<mother-pane id="${this.id}">
                 ${this.threadList}
             </mother-pane>`;

--- a/src/ChatUnion/Root/RootCulture.js
+++ b/src/ChatUnion/Root/RootCulture.js
@@ -64,7 +64,7 @@ export default class RootCulture extends Culture {
         this.chatBoxes.forEach(chatBox => chatBox.render());
     }
 
-    templates_base() {
+    template() {
         return `<root id="${this.id}">
             ${this.menu}
             ${this.motherPane}

--- a/src/ChatUnion/ThreadList/ThreadListCulture.js
+++ b/src/ChatUnion/ThreadList/ThreadListCulture.js
@@ -38,7 +38,7 @@ export default class ThreadListCulture extends Culture {
         });
     }
 
-    templates_base() {
+    template() {
         return `<thread-list id="${this.id}"></thread-list>`;
     }
 

--- a/src/ChatUnion/ThreadPreview/ThreadPreviewCulture.js
+++ b/src/ChatUnion/ThreadPreview/ThreadPreviewCulture.js
@@ -33,7 +33,7 @@ export default class ThreadPreviewCulture extends Culture {
         return this.rep.thread;
     }
 
-    templates_base() {
+    template() {
         var active = this.rep.active ? 'active' : '';
 
         return `<thread-preview id="${this.id}" class="${active}">

--- a/src/ChatUnion/ThreadsPopover/ThreadsPopoverCulture.js
+++ b/src/ChatUnion/ThreadsPopover/ThreadsPopoverCulture.js
@@ -24,7 +24,7 @@ export default class ThreadsPopoverCulture extends Culture {
         return false;
     }
 
-    templates_base() {
+    template() {
         var visible = this.rep.visible ? 'visible' : '';
 
         return `<threads-popover id="${this.id}" class="${visible}">


### PR DESCRIPTION
Switch to the latest politburo and fix old usages of `template` function in the cultures.

New version of politburo has a `template` function in the cultures. Seeing `templates_base` and not `template` was confusing in this implementation of cultures.